### PR TITLE
avoid throwing for n/a parameters

### DIFF
--- a/hekatoolslib/PMparameters.h
+++ b/hekatoolslib/PMparameters.h
@@ -86,7 +86,14 @@ namespace hkLib {
 		template<std::size_t N>void formatUserParamDesc(const hkTreeNode& node, std::size_t offset, std::ostream& ss) const {
 			ss << "(name,unit):[";
 			for (std::size_t i = 0; i < N; ++i) {
-				ss << node.getUserParamDescr(offset + i * UserParamDescr::Size) << ';';
+				auto d = node.getUserParamDescr(offset + i * UserParamDescr::Size);
+				if (d) {
+					ss << *d << ';';
+				}
+				else {
+					ss << "n/a";
+					break;
+				}
 			}
 			ss << ']';
 		}

--- a/hekatoolslib/hkTree.cpp
+++ b/hekatoolslib/hkTree.cpp
@@ -135,15 +135,18 @@ namespace hkLib {
 		return Data[offset];
 	}
 
-	const UserParamDescr hkTreeNode::getUserParamDescr(std::size_t offset) const
+	const std::optional<UserParamDescr> hkTreeNode::getUserParamDescr(std::size_t offset) const
 	{
 		if (len < offset + UserParamDescr::Size) {
-			throw std::out_of_range("offset too large while accessing tree node");
+			//throw std::out_of_range("offset too large while accessing tree node");
+			return std::nullopt;
 		}
-		return {
-			getString<UserParamDescr::SizeName>(offset),
-			getString<UserParamDescr::SizeUnit>(offset + UserParamDescr::SizeName)
-		};
+		else {
+			return { UserParamDescr{
+				getString<UserParamDescr::SizeName>(offset),
+				getString<UserParamDescr::SizeUnit>(offset + UserParamDescr::SizeName) }
+			};
+		}
 	}
 
 	const std::string_view hkTreeNode::getString(std::size_t offset) const

--- a/hekatoolslib/hkTree.h
+++ b/hekatoolslib/hkTree.h
@@ -26,6 +26,7 @@
 #include <ostream>
 #include <vector>
 #include <array>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <algorithm>
@@ -234,8 +235,22 @@ namespace hkLib {
                 throw std::out_of_range("offset too large while accessing tree node");
             }
             return extractValueNoCheck<T>(offset);
-        }
-
+        };
+        /// <summary>
+        /// tries to extract a value from record data, swaps bytes if needed
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="offset"></param>
+        /// <returns>std::optional containing value if offset is valid</returns>
+        template<typename T> std::optional<T> extractValueOpt(std::size_t offset) const
+        {
+            if (len < offset + sizeof(T)) {
+                return std::nullopt;
+            }
+            else {
+                return extractValueNoCheck<T>(offset);
+            }
+        };
         /// <summary>
         /// extract a value from record data, swaps bytes if needed,
         /// return default value
@@ -268,11 +283,11 @@ namespace hkLib {
         }
         char getChar(std::size_t offset) const;
         const std::string_view getString(std::size_t offset) const;
-        const UserParamDescr getUserParamDescr(std::size_t offset) const;
+        const std::optional<UserParamDescr> getUserParamDescr(std::size_t offset) const;
         template<std::size_t N> const std::string_view getString(std::size_t offset) const
         {
             if (len < offset + N) {
-                throw std::out_of_range("offset to large while accessing tree node");
+                return "n/a";
             }
             const auto* p = Data + offset;
             if (p[N - 1]) {


### PR DESCRIPTION
Since C++17 we should avoid throwing exceptions to indicate missing values where they are sometime expected.